### PR TITLE
Add 'open' flag to browser command

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ Escapes and unescapes HTML
 Starts a simple web server to serve static content. You can specify
 hostname and port and must set a folder to serve.
 
+You can also pass an option `-o` to open your default system browser
+that points automatically to the served url.
+
 ## Configuration
 You can configure a some default behaviors of dt to fit your needs.
 Just place a file `.dt.yaml` into your home directory, you can configure
@@ -135,6 +138,7 @@ the following options:
 server:
   port: 3001
   address: 127.0.0.1
+  openBrowser: true
 uuid:
   namespace: cacae610-c76a-4736-90ef-0271126b4346
   version: 4

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"github.com/chclaus/dt/cmd"
 	"github.com/chclaus/dt/config"
+	"github.com/chclaus/dt/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"net/http"
@@ -57,8 +58,11 @@ var serverCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		fmt.Printf("Serving %s on %s\n", path, addr)
+		if srv.OpenBrowser {
+			utils.Open("http://" + addr)
+		}
 
+		fmt.Printf("Serving %s on %s\n", path, addr)
 		http.ListenAndServe(addr, nil)
 	},
 	Example: ``,
@@ -71,6 +75,8 @@ func init() {
 
 	serverCmd.Flags().StringP("address", "a", "0.0.0.0", "the hostname or ip address")
 	serverCmd.Flags().StringP("port", "p", "3000", "the listening port")
+	serverCmd.Flags().BoolP("open", "o", false, "open a browser window")
 	viper.BindPFlag("server.port", serverCmd.Flags().Lookup("port"))
 	viper.BindPFlag("server.address", serverCmd.Flags().Lookup("address"))
+	viper.BindPFlag("server.openBrowser", serverCmd.Flags().Lookup("open"))
 }

--- a/cmd/uri/encode.go
+++ b/cmd/uri/encode.go
@@ -40,7 +40,7 @@ var encodeCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(utils.EncodeUri(args[0]))
+		fmt.Println(utils.EncodeURI(args[0]))
 	},
 	Example: "dt uri encode http://www.github.com",
 }

--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 )
 
+// Config is the root collection of command configurations
 type Config struct {
 	Server ServerConfig
 	Base64 Base64Config
@@ -15,32 +16,40 @@ type Config struct {
 	Hash   HashConfig
 }
 
+// ServerConfig allows configuration settings of the server cmd
 type ServerConfig struct {
-	Address string
-	Port    string
+	Address     string
+	Port        string
+	OpenBrowser bool
 }
 
+// Base64Config allows configuration settings of the base64 cmd
 type Base64Config struct {
 	Encoding string
 }
 
+// RandomConfig allows configuration settings of the random cmd
 type RandomConfig struct {
 	Algorithm string
 	Length    int
 }
 
+// UUIDConfig allows configuration settings of the uuid cmd
 type UUIDConfig struct {
 	Namespace string
 	Version   int
 }
 
+// HashConfig allows configuration settings of the hash cmd
 type HashConfig struct {
 	Algorithm string
 	Cost      int
 }
 
+// Cfg the root object of the configuration
 var Cfg *Config
 
+// InitConfig initializes the configuration if provided.
 func InitConfig() {
 	home, err := homedir.Dir()
 	if err != nil {

--- a/examples/config-sample.yaml
+++ b/examples/config-sample.yaml
@@ -9,6 +9,9 @@ server:
   # Defines the hostname or IP address of the server.
   address: 127.0.0.1
 
+  # Defines if a browser window should opens that points automatically to the served url
+  openBrowser: true
+
 
 #
 # Configuration of the uuid command: dt uuid

--- a/utils/random.go
+++ b/utils/random.go
@@ -36,8 +36,8 @@ const ALPH = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 // SPECIAL are special characters
 const SPECIAL = "!#$%&()*+,-./:;><?^_"
 
-// PARALLEL_LIMIT is the limit for concurrent execution of random char generations
-const PARALLEL_LIMIT = 100
+// parallelLimit is the limit for concurrent execution of random char generations
+const parallelLimit = 100
 
 // Source defines a string of letters used as source for a random string
 type Source interface {
@@ -79,11 +79,11 @@ func Random(n int, a Source) string {
 	l := len(letters)
 	r := make(chan string)
 	result := make([]string, n)
-	sem := make(Semaphore, PARALLEL_LIMIT)
+	sem := make(Semaphore, parallelLimit)
 
 	for i := 0; i < n; i++ {
 		go func(numLetters int, letters string) {
-			// Wait if there are more concurrent executions than the PARALLEL_LIMIT allows
+			// Wait if there are more concurrent executions than the parallelLimit allows
 			sem.Acquire(1)
 			defer sem.Release(1)
 

--- a/utils/server.go
+++ b/utils/server.go
@@ -18,42 +18,33 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package uri
+package utils
 
 import (
-	"fmt"
-
 	"errors"
-	"github.com/chclaus/dt/utils"
-	"github.com/spf13/cobra"
-	"os"
+	"log"
+	"os/exec"
+	"runtime"
 )
 
-// decodeCmd represents the uri decode command
-var decodeCmd = &cobra.Command{
-	Use:   "decode",
-	Short: "Decodes an URI-encoded string",
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) != 1 {
-			return errors.New("you have to specify a string which should be decoded")
-		}
 
-		return nil
-	},
-	Run: func(cmd *cobra.Command, args []string) {
-		result, err := utils.DecodeURI(args[0])
+// Open opens the default system browser and points to the given url.
+func Open(url string) {
+	var cmd *exec.Cmd
 
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
+	switch runtime.GOOS {
+	case "linux":
+		cmd = exec.Command("xdg-open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	case "darwin":
+		cmd = exec.Command("open", url)
+	default:
+		log.Fatal(errors.New("Unsupported operating system"))
+	}
 
-		fmt.Println(result)
-		return
-	},
-	Example: "dt uri decode http%3A%2F%2Fwww.github.com",
-}
-
-func init() {
-	uriCmd.AddCommand(decodeCmd)
+	err := cmd.Start()
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/utils/uri.go
+++ b/utils/uri.go
@@ -25,8 +25,8 @@ import (
 	"strings"
 )
 
-// EncodeUri encodes a string so it can safely placed inside an URL.
-func EncodeUri(uri string) string {
+// EncodeURI encodes a string so it can safely placed inside an URL.
+func EncodeURI(uri string) string {
 	uriComponents := strings.Split(uri, " ")
 
 	for i, s := range uriComponents {
@@ -36,8 +36,8 @@ func EncodeUri(uri string) string {
 	return strings.Join(uriComponents, "%20")
 }
 
-// DecodeUri does the inverse transformation of EncodeUri. Currently it's
+// DecodeURI does the inverse transformation of EncodeUri. Currently it's
 // just a delegate for uri.QueryUnescape.
-func DecodeUri(decodedUri string) (string, error) {
-	return url.QueryUnescape(decodedUri)
+func DecodeURI(decodedURI string) (string, error) {
+	return url.QueryUnescape(decodedURI)
 }


### PR DESCRIPTION
#### Summary
Add a `-o` flag to server command to allow automatically browser startup while starting a server. The flag's default value is false to be compatible with already shipped versions of _dt_. There is also a new configuration file option for this flag.

#### Ticket Link
https://github.com/chclaus/dt/issues/14

#### Checklist
- [x] Added API documentation and updated Readme (required for all new commands)
- [x] Updated existing command
- [x] Update dependency or does other cleanups
